### PR TITLE
(cmake-build) remove unneeded gtk3-dependency from base

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -327,7 +327,7 @@ function(wx_set_target_properties target_name is_base)
             PUBLIC ${WIN32_LIBRARIES})
     endif()
 
-    if(wxTOOLKIT_LIBRARIES)
+    if(wxTOOLKIT_LIBRARIES AND NOT ${is_base})
         target_link_libraries(${target_name}
             PUBLIC ${wxTOOLKIT_LIBRARIES})
     endif()


### PR DESCRIPTION
tested only with linux / wxGTK3+wxGTK2 (sorry)